### PR TITLE
Add support for evaluating dynamic user and append data

### DIFF
--- a/modules/app/models/workflow-actions.xqy
+++ b/modules/app/models/workflow-actions.xqy
@@ -45,13 +45,28 @@ declare function update-generic($processId as xs:string,$data as node()*,$attach
   let $_ := xdmp:log("In wfa:update-generic")
   (: TODO complete this method :)
   (: TODO security sanity checks - ensure nothing is updated that shouldn't be :)
-  (: Complete step and move on :)
-  let $updateData :=
-    for $dn in $data
-    return
-      ()
-  let $updateAttachments := ()
-  return ()
+  (: Complete step and move on :)                
+   
+  let $previous-data := fn:doc(wfu:getProcessUri($processId))/wf:process/wf:data
+  let $previous-attach := fn:doc(wfu:getProcessUri($processId))/wf:process/wf:attachments
+  
+  return (
+      xdmp:node-replace(fn:doc(wfu:getProcessUri($processId))/wf:process/wf:data,
+        (: Keep previous data if not newly sent and add new elements :)
+        element wf:data {
+          ($previous-data/* except $data/(let $qname := fn:node-name(.) return $previous-data/*[fn:node-name(.) eq $qname])),
+          $data
+        } 
+      ),
+      xdmp:node-replace(fn:doc(wfu:getProcessUri($processId))/wf:process/wf:attachments, 
+        (: Keep previous data if not newly sent and add new elements :)
+        element wf:attachments {
+          ($previous-attach/* except $previous-attach/*[@name eq $attachments/@name]),
+          $attachments
+        }
+      )
+  )
+
 };
 
 (:

--- a/modules/app/models/workflow-util.xqy
+++ b/modules/app/models/workflow-util.xqy
@@ -336,7 +336,7 @@ declare function m:evaluateOLD($processUri as xs:string,$namespaces as element(w
 };
 :)
 
-declare function m:evaluate($processUri as xs:string,$namespaces as element(wf:namespace)*,$xpath as xs:string) as xs:boolean {
+declare function m:evaluate($processUri as xs:string,$namespaces as element(wf:namespace)*,$xpath as xs:string) as item() {
   let $ns :=
     for $namespace in $namespaces
     return


### PR DESCRIPTION
The original evaluate function could return only xs:boolean but for evaluating a dynamic user name it should support a different type. To generalize this I changed the return type to  item()
